### PR TITLE
Fix index list of principles

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -66,7 +66,6 @@ Learn:::
 *** Stay responsive
 *** Accept uncertainty
 *** Embrace failure
-*** Build reliability despite unreliable foundations
 *** Assert autonomy
 *** Tailor consistency
 *** Decouple time


### PR DESCRIPTION
Remove `Build reliability despite unreliable foundations` from the list of principles on the index page.